### PR TITLE
Teletext heartbeat

### DIFF
--- a/packager/media/chunking/text_chunker.cc
+++ b/packager/media/chunking/text_chunker.cc
@@ -92,7 +92,9 @@ Status TextChunker::OnTextSample(std::shared_ptr<const TextSample> sample) {
     RETURN_IF_ERROR(DispatchSegment(segment_duration_));
   }
 
-  samples_in_current_segment_.push_back(std::move(sample));
+  if (sample->duration() > 0) {
+    samples_in_current_segment_.push_back(std::move(sample));
+  }
 
   return Status::OK;
 }

--- a/packager/media/chunking/text_chunker_unittest.cc
+++ b/packager/media/chunking/text_chunker_unittest.cc
@@ -270,6 +270,74 @@ TEST_F(TextChunkerTest, OutputsEmptySegments) {
   ASSERT_OK(Input(kInput)->FlushAllDownstreams());
 }
 
+// Verify that segments are outputted, including empty ones as will get
+// outputted if heart-beat samples with duration are received
+//
+// Segment Duration = 100 MS
+//
+// TIME (ms):0     5     1     1     2
+//                 0     0     5     0
+//                       0     0     0
+// SAMPLES  :[--A--]
+//                       H     H     H
+// SEGMENTS :            ^           ^
+//
+TEST_F(TextChunkerTest, OutputTrailingSegments) {
+  const double kSegmentDurationSec = 0.1;
+  const int64_t kSegmentDurationMs = 100;
+
+  const int64_t kSegment0Start = 0;
+  const int64_t kSegment1Start = 100;
+
+  const int64_t kSampleAStart = 0;
+  const int64_t kSampleAEnd = 50;
+
+  const int64_t kHeartBeatA = 100;
+  const int64_t kHeartBeatB = 150;
+  const int64_t kHeartBeatC = 200;
+
+  Init(kSegmentDurationSec);
+
+  {
+    testing::InSequence s;
+
+    EXPECT_CALL(*Output(kOutput),
+                OnProcess(IsStreamInfo(kStreamIndex, _, _, _)));
+
+    // Segment One
+    EXPECT_CALL(*Output(kOutput),
+                OnProcess(IsTextSample(_, kNoId, kSampleAStart, kSampleAEnd)));
+    EXPECT_CALL(*Output(kOutput),
+                OnProcess(IsSegmentInfo(kStreamIndex, kSegment0Start,
+                                        kSegmentDurationMs, !kSubSegment,
+                                        !kEncrypted)));
+
+    // Segment Two (empty segment)
+    EXPECT_CALL(*Output(kOutput),
+                OnProcess(IsSegmentInfo(kStreamIndex, kSegment1Start,
+                                        kSegmentDurationMs, !kSubSegment,
+                                        !kEncrypted)));
+
+    EXPECT_CALL(*Output(kOutput), OnFlush(kStreamIndex));
+  }
+
+  ASSERT_OK(Input(kInput)->Dispatch(StreamData::FromStreamInfo(
+      kStreamIndex, GetTextStreamInfo(kTimescaleMs))));
+  ASSERT_OK(Input(kInput)->Dispatch(StreamData::FromTextSample(
+      kStreamIndex,
+      GetTextSample(kNoId, kSampleAStart, kSampleAEnd, kNoPayload))));
+  ASSERT_OK(Input(kInput)->Dispatch(StreamData::FromTextSample(
+      kStreamIndex,
+      GetTextSample(kNoId, kHeartBeatA, kHeartBeatA, kNoPayload))));
+  ASSERT_OK(Input(kInput)->Dispatch(StreamData::FromTextSample(
+      kStreamIndex,
+      GetTextSample(kNoId, kHeartBeatB, kHeartBeatB, kNoPayload))));
+  ASSERT_OK(Input(kInput)->Dispatch(StreamData::FromTextSample(
+      kStreamIndex,
+      GetTextSample(kNoId, kHeartBeatC, kHeartBeatC, kNoPayload))));
+  ASSERT_OK(Input(kInput)->FlushAllDownstreams());
+}
+
 // Verify that samples that overlap multiple samples get dispatch in all
 // segments.
 //

--- a/packager/media/formats/mp2t/es_parser_teletext.h
+++ b/packager/media/formats/mp2t/es_parser_teletext.h
@@ -35,6 +35,7 @@ class EsParserTeletext : public EsParser {
   void Reset() override;
 
  private:
+  void ResetPTS(int64_t pts);
   using RowColReplacementMap =
       std::unordered_map<uint8_t, std::unordered_map<uint8_t, std::string>>;
 
@@ -62,6 +63,7 @@ class EsParserTeletext : public EsParser {
   TextRow BuildRow(const uint8_t* data_block, const uint8_t row) const;
   void ParsePacket26(const uint8_t* data_block);
   void UpdateNationalSubset(const uint8_t national_subset[13][3]);
+  void SendHeartBeatSample(const int64_t pts);
 
   static void SetPacket26ReplacementString(
       RowColReplacementMap& replacement_map,
@@ -80,6 +82,7 @@ class EsParserTeletext : public EsParser {
   uint8_t charset_code_;
   char current_charset_[96][3];
   int64_t last_pts_;
+  bool inside_sample_;
 };
 
 }  // namespace mp2t

--- a/packager/media/formats/mp2t/es_parser_teletext_unittest.cc
+++ b/packager/media/formats/mp2t/es_parser_teletext_unittest.cc
@@ -225,6 +225,9 @@ const uint8_t PES_1173713[] = {
     0x83, 0x73, 0x2a, 0xcb, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04,
     0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04};
 
+// Minimal HeartBeat PES payload
+const uint8_t PES_MINIMAL_HEARTBEAT[] = {0xff};
+
 const uint32_t kPesPid = 123;
 
 }  // namespace
@@ -322,7 +325,8 @@ TEST_F(EsParserTeletextTest, multiple_lines_with_same_pts) {
   EXPECT_TRUE(parse_result);
 
   EXPECT_NE(nullptr, text_sample_.get());
-  EXPECT_EQ(8768632, text_sample_->start_time());
+  EXPECT_EQ(8773087, text_sample_->start_time());  // The time is from first
+                                                   // row, not from packet 26
   EXPECT_EQ(8937764, text_sample_->EndTime());
   EXPECT_EQ(3, text_sample_->body().sub_fragments.size());
   EXPECT_EQ("-Sí?", text_sample_->body().sub_fragments[0].body);
@@ -420,6 +424,35 @@ TEST_F(EsParserTeletextTest, consecutive_lines_with_slightly_different_pts) {
   EXPECT_EQ("yellow",
             text_sample_->body().sub_fragments[2].style.backgroundColor);
   EXPECT_EQ("blue", text_sample_->body().sub_fragments[2].style.color);
+}
+
+// An empty TextSample should be generated every 500ms as no text
+// but other PES packets are received.
+TEST_F(EsParserTeletextTest, generate_zero_duration_samples_if_no_text) {
+  auto on_new_stream = std::bind(&EsParserTeletextTest::OnNewStreamInfo, this,
+                                 kPesPid, std::placeholders::_1);
+  auto on_emit_text = std::bind(&EsParserTeletextTest::OnEmitTextSample, this,
+                                kPesPid, std::placeholders::_1);
+
+  std::unique_ptr<EsParserTeletext> es_parser_teletext(new EsParserTeletext(
+      kPesPid, on_new_stream, on_emit_text, DESCRIPTOR, 12));
+
+  int64_t pts = 12000;
+  for (int i = 0; i < 5; i++) {
+    auto parse_result = es_parser_teletext->Parse(
+        PES_MINIMAL_HEARTBEAT, sizeof(PES_MINIMAL_HEARTBEAT), pts, 0);
+    EXPECT_TRUE(parse_result);
+    pts += 22500;  // 0.25s
+  }
+
+  EXPECT_NE(nullptr, text_sample_.get());
+  EXPECT_EQ(2, text_samples_.size());
+  int64_t target_pts = 12000 + 45000;
+  for (auto const& sample : text_samples_) {
+    EXPECT_EQ(0, sample->duration());
+    EXPECT_EQ(target_pts, sample->start_time());
+    target_pts += 45000;
+  }
 }
 
 }  // namespace mp2t

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -657,10 +657,10 @@ Status CreateAudioVideoJobs(
       }
 
       std::vector<std::shared_ptr<MediaHandler>> handlers;
-      if (is_text) {
+      /*if (is_text) {
         handlers.emplace_back(std::make_shared<TextPadder>(
             packaging_params.default_text_zero_bias_ms));
-      }
+      }*/
       if (sync_points) {
         handlers.emplace_back(cue_aligner);
       }


### PR DESCRIPTION
Shaka-packager only generates segment when sample callbacks provide data. 

This PR creates heartbeat TextSamples as PES packets with PTS timestamps are arriving on the teletext PID if there is no text cues. On the test stream there was such data every 20ms, so the frequency is limited to at most every 500ms.

Another fix is that TextSample start is updated as the first row arrives, since that may happen quite some time after an input PES packet with teletext packet26 which sets the first timestamp. This solves the issue of too long subtitles.

For the case that there is no teletext data between text cues, we need another PTS source, such as video. That is not covered here. 